### PR TITLE
DL-2714 update dependencies and plugins

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 HM Revenue & Customs
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -31,8 +31,8 @@ private object AppDependencies {
   private val playReactivemongoVersion = "7.22.0-play-26"
   private val hmrcTestVersion = "3.9.0-play-26"
 
-  private val emailAddress = "3.2.0"
-  private val mockitoVersion = "2.27.0"
+  private val emailAddress = "3.4.0"
+  private val mockitoVersion = "3.2.4"
   private val scalatestPlusPlayVersion = "3.1.2"
   private val jSoupVersion = "1.12.1"
   private val pegdownVersion = "1.6.0"
@@ -40,7 +40,7 @@ private object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "simple-reactivemongo" % playReactivemongoVersion,
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.39.0",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
     "uk.gov.hmrc" %% "domain" % domainVersion,
     "uk.gov.hmrc" %% "emailaddress" % emailAddress
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 


### PR DESCRIPTION
DL-2714

**Maintenance** 

Update dependencies and plugins
Had to add new LICENSE for sbt auto plugin to compile - as per sbt auto build repo
Unable to upgrade scala scalatestplus-play to 3.1.3 without major errors
Unable to upgrade sbt-plugin to version 2.6.24 or 2.6.25 (DL-2707)

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
